### PR TITLE
fix(client): make type_sheet, intents and shard_count actually optional

### DIFF
--- a/nextcord/client/client.py
+++ b/nextcord/client/client.py
@@ -22,13 +22,12 @@ from __future__ import annotations
 from logging import getLogger
 from typing import TYPE_CHECKING
 
+from ..type_sheet import TypeSheet
 from .protocols.client import Client as BaseClient
 from .state import State
-from ..type_sheet import TypeSheet
 
 if TYPE_CHECKING:
     from typing import Optional
-
 
 
 logger = getLogger(__name__)

--- a/nextcord/client/client.py
+++ b/nextcord/client/client.py
@@ -24,11 +24,11 @@ from typing import TYPE_CHECKING
 
 from .protocols.client import Client as BaseClient
 from .state import State
+from ..type_sheet import TypeSheet
 
 if TYPE_CHECKING:
     from typing import Optional
 
-    from ..type_sheet import TypeSheet
 
 
 logger = getLogger(__name__)
@@ -40,9 +40,11 @@ class Client(BaseClient):
         token: str,
         *,
         type_sheet: Optional[TypeSheet] = None,
-        intents: Optional[int] = None,
+        intents: Optional[int] = 0,
         shard_count: Optional[int] = None,
     ) -> None:
+        if type_sheet is None:
+            type_sheet = TypeSheet.default()
         self.state: State = State(type_sheet, token, intents, shard_count)
 
     async def connect(self) -> None:

--- a/nextcord/core/gateway/gateway.py
+++ b/nextcord/core/gateway/gateway.py
@@ -80,6 +80,8 @@ class Gateway(GatewayProtocol):
         if self.shard_count is None:
             self.shard_count = gateway_info["shards"]
 
+        self.state.shard_count = self.shard_count
+
         session_start_limit = gateway_info["session_start_limit"]
         self.max_concurrency = session_start_limit["max_concurrency"]
 


### PR DESCRIPTION
This PR fixes the optional required parameters type_sheet, intents and shard_count to be actually optional.