### PR TITLE
chore: general markdown fixes/improvements

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,13 +1,17 @@
-# Asking questions
-Please don't use GitHub issues to ask a question, we would much rather you use one of the resources below.  
+# Contributing
 
-- The official support server: https://discord.gg/ZebatWssCB (Please see the #help channel)
+## Asking Questions
+
+Please don't use GitHub issues to ask a question, we would much rather you use one of the resources below.
+
+- [The official support server](https://discord.gg/ZebatWssCB) (Please see the #help channel)
 - [The FAQ in the documentation](https://nextcord.readthedocs.io/en/latest/faq.html)
 - [StackOverflow's `nextcord` tag](https://stackoverflow.com/questions/tagged/nextcord)
 - [The discussions page](https://github.com/nextcord/nextcord/discussions)
 
-# Rules for contributing
-We use the [angular style](https://kapeli.com/cheat_sheets/Conventional_Commits.docset/Contents/Resources/Documents/index) of conventional commits.  
-Test your code before pushing/making a PR! I cannot stress this enough.  
-When linking PRs/Issues please use the shorthand `#123` and not full URLs.  
-Format your changes! Please see `lint.sh` for linting
+## Rules for Contributing
+
+1. We use the [angular style](https://kapeli.com/cheat_sheets/Conventional_Commits.docset/Contents/Resources/Documents/index) of conventional commits.
+2. Test your code before pushing/making a PR! I cannot stress this enough.
+3. When linking PRs/Issues please use the shorthand `#123` and not full URLs.
+4. Format your changes! Please see `lint.sh` for linting

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Nextcord V3
+
 A fast modular discord API wrapper written for python
 
 ## Installation


### PR DESCRIPTION
- Use headings correctly
- Number the rules
- Make support server link consistent
- Remove trailing whitespace