### PR TITLE
chore: change black settings and add it to pyproject tasks

### DIFF
--- a/nextcord/core/gateway/protocols/gateway.py
+++ b/nextcord/core/gateway/protocols/gateway.py
@@ -55,12 +55,8 @@ class GatewayProtocol(Protocol):
     def get_identify_ratelimiter(self, shard_id: int) -> TimesPer:
         ...
 
-    def _shard_dispatch(
-        self, event_name: str, shard: ShardProtocol, *args: Any
-    ) -> None:
+    def _shard_dispatch(self, event_name: str, shard: ShardProtocol, *args: Any) -> None:
         ...
 
-    def _shard_raw_dispatch(
-        self, opcode: int, shard: ShardProtocol, *args: Any
-    ) -> None:
+    def _shard_raw_dispatch(self, opcode: int, shard: ShardProtocol, *args: Any) -> None:
         ...

--- a/nextcord/core/gateway/shard.py
+++ b/nextcord/core/gateway/shard.py
@@ -86,9 +86,7 @@ class Shard(ShardProtocol):
 
         # Register handles
         self.opcode_dispatcher.add_listener(OpcodeEnum.HELLO.value, self._handle_hello)
-        self.opcode_dispatcher.add_listener(
-            OpcodeEnum.HEARTBEAT_ACK.value, self._handle_heartbeat_ack
-        )
+        self.opcode_dispatcher.add_listener(OpcodeEnum.HEARTBEAT_ACK.value, self._handle_heartbeat_ack)
         self.opcode_dispatcher.add_listener(None, self._handle_set_sequence)
         self.event_dispatcher.add_listener(None, self._handle_raw_dispatch)
         self.event_dispatcher.add_listener("READY", self._handle_ready)
@@ -155,9 +153,7 @@ class Shard(ShardProtocol):
         except ValueError:
             self._logger.warning("Disconnect with unknown close code %s", close_code)
         else:
-            self._logger.info(
-                "Disconnected with code %s (%s)", close_code, close_code_enum
-            )
+            self._logger.info("Disconnected with code %s (%s)", close_code, close_code_enum)
         self.disconnect_dispatcher.dispatch(close_code)
 
     async def _heartbeat_loop(self, heartbeat_interval: float) -> None:
@@ -231,9 +227,7 @@ class Shard(ShardProtocol):
             CloseCodeEnum.INVALID_API_VERSION,
         ]:
             # TODO: Error? These should never happen with the current sharding implementation although throwing a custom error might be a good idea?
-            raise NextcordException(
-                f"Unexpected discord close code: {CloseCodeEnum(close_code)}"
-            )
+            raise NextcordException(f"Unexpected discord close code: {CloseCodeEnum(close_code)}")
 
         # Errors which require a new session
         if close_code in [

--- a/nextcord/core/http.py
+++ b/nextcord/core/http.py
@@ -127,9 +127,7 @@ class Bucket(BucketProtocol):
             # Ratelimit pending, let's wait
             future = Future()
             self._pending.append(future)
-            logger.debug(
-                "Waiting for %s to clear up. %s pending", str(self), len(self._pending)
-            )
+            logger.debug("Waiting for %s to clear up. %s pending", str(self), len(self._pending))
             await future
         self._reserved += 1
         return self
@@ -154,18 +152,12 @@ class HTTPClient(HTTPClientProtocol):
 
         self.max_retries = max_retries
         self._global_lock = self.state.type_sheet.http_bucket(Route("POST", "/global"))
-        self._webhook_global_lock = self.state.type_sheet.http_bucket(
-            Route("POST", "/global/webhook")
-        )
+        self._webhook_global_lock = self.state.type_sheet.http_bucket(Route("POST", "/global/webhook"))
         self._session = ClientSession(json_serialize=json.dumps)
         self._buckets: dict[str, BucketProtocol] = {}
         self._http_errors = defaultdict((lambda: HTTPException), {})
 
-        self._headers = {
-            "User-Agent": "DiscordBot (https://github.com/nextcord/nextcord, {})".format(
-                __version__
-            )
-        }
+        self._headers = {"User-Agent": "DiscordBot (https://github.com/nextcord/nextcord, {})".format(__version__)}
         if self.state.token:
             self._headers["Authorization"] = f"Bot {self.state.token}"
 
@@ -176,9 +168,7 @@ class HTTPClient(HTTPClientProtocol):
         headers: dict[str, Any] = None,
         **kwargs,
     ) -> ClientResponse:
-        global_lock = (
-            self._webhook_global_lock if route.use_webhook_global else self._global_lock
-        )
+        global_lock = self._webhook_global_lock if route.use_webhook_global else self._global_lock
 
         if headers is None:
             headers = {}
@@ -217,9 +207,7 @@ class HTTPClient(HTTPClientProtocol):
                         logger.debug("Ratelimit exceeded")
                         continue
                     error = await r.json()
-                    raise self._http_errors[status](
-                        r.status, error["code"], error["message"]
-                    )
+                    raise self._http_errors[status](r.status, error["code"], error["message"])
 
                 return r
 
@@ -228,9 +216,7 @@ class HTTPClient(HTTPClientProtocol):
         )
 
     async def ws_connect(self, url) -> ClientWebSocketResponse:
-        return await self._session.ws_connect(
-            url, max_msg_size=0, autoclose=False, headers=self._headers
-        )
+        return await self._session.ws_connect(url, max_msg_size=0, autoclose=False, headers=self._headers)
 
     async def close(self):
         await self._session.close()

--- a/nextcord/dispatcher.py
+++ b/nextcord/dispatcher.py
@@ -45,9 +45,7 @@ class Dispatcher:
 
         # Predicates
         for predicate_info in self.predicates:
-            self.loop.create_task(
-                self._dispatch_predicate(predicate_info, event_name, *args)
-            )
+            self.loop.create_task(self._dispatch_predicate(predicate_info, event_name, *args))
 
         for listener in self.global_listeners:
             self.loop.create_task(listener(event_name, *args))

--- a/nextcord/types/base_flag.py
+++ b/nextcord/types/base_flag.py
@@ -9,9 +9,7 @@ class IntFlags:
 
         flags: Optional[list[str]] = getattr(self, "flags", None)
         if flags is None:
-            raise NextcordException(
-                "A flags attribute has to defined"
-            )  # TODO: Maybe make this a warning?
+            raise NextcordException("A flags attribute has to defined")  # TODO: Maybe make this a warning?
 
         for flag_name, flag_value in kwargs.items():
             flag_name = flag_name.upper()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,12 +29,20 @@ cchardet = {version = "^2.1.7", optional = true}
 isort = "^5.10.1"
 black = "^21.12b0"
 pytest = "^6.2.5"
+taskipy = "^1.9.0"
 
 [tool.poetry.extras]
 speed = ["orjson", "aiodns", "Brotli", "cchardet"]
 
 [tool.isort]
 profile = "black"
+
+[tool.black]
+line-length = 120
+target-version = ["py39"]
+
+[tool.taskipy.tasks]
+lint = "black . && isort --profile black ."
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
This PR adds a taskipy task to the pyproject.toml meaning you can run a task cross-platform to lint.

It also changes the black settings to have a line length of 120 which is a more sane default. This also reformats the files with the new black settings.